### PR TITLE
AutoExtractHtml and AutoExtractWebPage objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+X.X.X (YYYY-MM-DD)
+------------------
+
+* ``AutoExtractHtml`` page input
+* ``AutoExtractWebPage`` and ``AutoExtractItemWebPage`` base page objects
+
 0.0.1 (2020-08-18)
 ------------------
 

--- a/autoextract_poet/__init__.py
+++ b/autoextract_poet/__init__.py
@@ -1,0 +1,2 @@
+from .page_inputs import AutoExtractHtml, AutoExtractArticleData, AutoExtractProductData
+from .pages import AutoExtractWebPage, AutoExtractItemWebPage

--- a/autoextract_poet/page_inputs.py
+++ b/autoextract_poet/page_inputs.py
@@ -8,6 +8,22 @@ from autoextract_poet.items import (
     Product,
 )
 
+
+@attr.s(auto_attribs=True)
+class AutoExtractHtml:
+    """A container for URL and HTML content retrieved from AutoExtract.
+
+    ``url`` should be an URL of the response (after all redirects),
+    not an URL of the request, if possible.
+
+    ``html`` should be browser HTML, converted to unicode
+    using the detected encoding of the response, preferably according
+    to the web browser rules (respecting Content-Type header, etc.)
+    """
+    url: str
+    html: str
+
+
 T = TypeVar("T", bound=Item)
 
 

--- a/autoextract_poet/pages.py
+++ b/autoextract_poet/pages.py
@@ -1,0 +1,16 @@
+import attr
+
+from autoextract_poet.page_inputs import AutoExtractHtml
+from web_poet import Injectable
+from web_poet.mixins import ResponseShortcutsMixin
+
+
+@attr.s(auto_attribs=True)
+class AutoExtractWebPage(Injectable, ResponseShortcutsMixin):
+    """Base Page Object which requires :class:`~.AutoExtractHtml`
+    and provides XPath / CSS shortcuts.
+
+    Use this class as a base class for Page Objects which work on
+    the browser HTML provided by AutoExtract.
+    """
+    response: AutoExtractHtml

--- a/autoextract_poet/pages.py
+++ b/autoextract_poet/pages.py
@@ -1,7 +1,7 @@
 import attr
 
 from autoextract_poet.page_inputs import AutoExtractHtml
-from web_poet import Injectable
+from web_poet import Injectable, ItemPage
 from web_poet.mixins import ResponseShortcutsMixin
 
 
@@ -14,3 +14,11 @@ class AutoExtractWebPage(Injectable, ResponseShortcutsMixin):
     the browser HTML provided by AutoExtract.
     """
     response: AutoExtractHtml
+
+
+@attr.s(auto_attribs=True)
+class AutoExtractItemWebPage(AutoExtractWebPage, ItemPage):
+    """:class:`AutoExtractWebPage` that requires the :meth:`to_item` method to
+    be implemented.
+    """
+    pass

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -2,7 +2,7 @@ import pytest
 
 from autoextract_poet.page_inputs import (
     AutoExtractArticleData,
-    AutoExtractProductData,
+    AutoExtractProductData, AutoExtractHtml,
 )
 
 from tests import load_fixture, item_equals_dict
@@ -20,3 +20,12 @@ def test_response_data(cls, results):
     item = response_data.to_item()
     assert isinstance(item, response_data.item_class)
     assert item_equals_dict(item, results[0][cls.item_key])
+
+
+def test_auto_extract_html():
+    url = "https://example.com"
+    html = "<html><body><p>Hello!</p></body></html>"
+    data = AutoExtractHtml(url, html)
+    assert data.url == url
+    assert data.html == html
+    assert AutoExtractHtml(url, html) == data

--- a/tests/test_page_inputs.py
+++ b/tests/test_page_inputs.py
@@ -1,8 +1,9 @@
 import pytest
 
-from autoextract_poet.page_inputs import (
+from autoextract_poet import (
     AutoExtractArticleData,
-    AutoExtractProductData, AutoExtractHtml,
+    AutoExtractProductData,
+    AutoExtractHtml,
 )
 
 from tests import load_fixture, item_equals_dict

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,7 +1,10 @@
 import pytest
 
-from autoextract_poet.page_inputs import AutoExtractHtml
-from autoextract_poet.pages import AutoExtractWebPage, AutoExtractItemWebPage
+from autoextract_poet import (
+    AutoExtractHtml,
+    AutoExtractWebPage,
+    AutoExtractItemWebPage,
+)
 
 
 @pytest.fixture

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,0 +1,11 @@
+from autoextract_poet.page_inputs import AutoExtractHtml
+from autoextract_poet.pages import AutoExtractWebPage
+
+
+def test_auto_extract_web_page():
+    url = "https://example.com"
+    html = "<html><body><p>Hello!</p></body></html>"
+    response_data = AutoExtractHtml(url, html)
+    page = AutoExtractWebPage(response_data)
+    assert  page.response == response_data
+    assert page.css("html body p::text").get() == "Hello!"

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -11,7 +11,12 @@ def auto_extract_html():
     return AutoExtractHtml(url, html)
 
 
-@pytest.mark.parametrize("cls", [AutoExtractWebPage, AutoExtractItemWebPage])
+class ConcreteItemWebPage(AutoExtractItemWebPage):
+    def to_item(self):
+        return "yeah!"
+
+
+@pytest.mark.parametrize("cls", [AutoExtractWebPage, ConcreteItemWebPage])
 def test_auto_extract_web_page_family(auto_extract_html, cls):
     page = cls(auto_extract_html)
     assert  page.response == auto_extract_html
@@ -21,9 +26,4 @@ def test_auto_extract_web_page_family(auto_extract_html, cls):
 def test_auto_extract_item_web_page(auto_extract_html):
     with pytest.raises(TypeError):
         AutoExtractItemWebPage(auto_extract_html).to_item()
-
-    class ItemWebPage(AutoExtractItemWebPage):
-        def to_item(self):
-            return "yeah!"
-
-    assert ItemWebPage(auto_extract_html).to_item() == "yeah!"
+    assert ConcreteItemWebPage(auto_extract_html).to_item() == "yeah!"

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,11 +1,29 @@
+import pytest
+
 from autoextract_poet.page_inputs import AutoExtractHtml
-from autoextract_poet.pages import AutoExtractWebPage
+from autoextract_poet.pages import AutoExtractWebPage, AutoExtractItemWebPage
 
 
-def test_auto_extract_web_page():
+@pytest.fixture
+def auto_extract_html():
     url = "https://example.com"
     html = "<html><body><p>Hello!</p></body></html>"
-    response_data = AutoExtractHtml(url, html)
-    page = AutoExtractWebPage(response_data)
-    assert  page.response == response_data
+    return AutoExtractHtml(url, html)
+
+
+@pytest.mark.parametrize("cls", [AutoExtractWebPage, AutoExtractItemWebPage])
+def test_auto_extract_web_page_family(auto_extract_html, cls):
+    page = cls(auto_extract_html)
+    assert  page.response == auto_extract_html
     assert page.css("html body p::text").get() == "Hello!"
+
+
+def test_auto_extract_item_web_page(auto_extract_html):
+    with pytest.raises(TypeError):
+        AutoExtractItemWebPage(auto_extract_html).to_item()
+
+    class ItemWebPage(AutoExtractItemWebPage):
+        def to_item(self):
+            return "yeah!"
+
+    assert ItemWebPage(auto_extract_html).to_item() == "yeah!"


### PR DESCRIPTION
Page input `AutoExtractHtml` and page object bases `AutoExtractWebPage` and `AutoExtractItemWebPage` defined for AutoExtract browser html the same way `ResponseData` and `WebPage` and `ItemWebPage` for web-poet. 