### PR TITLE
Unknown attributes are now preserved internally and a new item adapter includes them in the serialization

### DIFF
--- a/autoextract_poet/__init__.py
+++ b/autoextract_poet/__init__.py
@@ -11,3 +11,4 @@ from .pages import (
     AutoExtractProductPage,
     AutoExtractProductListPage,
 )
+from .adapters import AutoExtractAdapter

--- a/autoextract_poet/adapters.py
+++ b/autoextract_poet/adapters.py
@@ -10,7 +10,8 @@ class AutoExtractAdapter(AttrsAdapter):
     """
     ``ItemAdapter`` for AutoExtract poet items that deals transparently with
     both the ``attr.s`` defined fields and the rest of unknown
-    fields received at item initialization.
+    fields received at item initialization, offering an unified view over
+    all the item fields.
 
     The utility is twofold. Firstly, it serves to ensure the
     pass-through of new fields from the API even if ``autoextract-poet``

--- a/autoextract_poet/adapters.py
+++ b/autoextract_poet/adapters.py
@@ -32,20 +32,20 @@ class AutoExtractAdapter(AttrsAdapter):
             return MappingProxyType({})
 
     def field_names(self) -> KeysView:
-        return KeysView({**self._fields_dict, **self.item._additional_attrs})
+        return KeysView({**self._fields_dict, **self.item._unknown_fields_dict})
 
     def __getitem__(self, field_name: str) -> Any:
         if field_name in self._fields_dict:
             return getattr(self.item, field_name)
-        elif field_name in self.item._additional_attrs:
-            return self.item._additional_attrs[field_name]
+        elif field_name in self.item._unknown_fields_dict:
+            return self.item._unknown_fields_dict[field_name]
         raise KeyError(field_name)
 
     def __setitem__(self, field_name: str, value: Any) -> None:
         if field_name in self._fields_dict:
             setattr(self.item, field_name, value)
         else:
-            self.item._additional_attrs[field_name] = value
+            self.item._unknown_fields_dict[field_name] = value
 
     def __delitem__(self, field_name: str) -> None:
         if field_name in self._fields_dict:
@@ -53,13 +53,13 @@ class AutoExtractAdapter(AttrsAdapter):
                 delattr(self.item, field_name)
             except AttributeError:
                 raise KeyError(field_name)
-        elif field_name in self.item._additional_attrs:
-            del self.item._additional_attrs[field_name]
+        elif field_name in self.item._unknown_fields_dict:
+            del self.item._unknown_fields_dict[field_name]
         else:
             raise KeyError(f"Object of type {self.item.__class__.__name__} does " +
                            f"not contain a field with name {field_name}")
 
     def __iter__(self) -> Iterator:
         fields = [attr for attr in self._fields_dict if hasattr(self.item, attr)]
-        fields.extend(attr for attr in self.item._additional_attrs if attr not in fields)
+        fields.extend(attr for attr in self.item._unknown_fields_dict if attr not in fields)
         return iter(fields)

--- a/autoextract_poet/adapters.py
+++ b/autoextract_poet/adapters.py
@@ -57,7 +57,7 @@ class AutoExtractAdapter(AttrsAdapter):
             del self.item._additional_attrs[field_name]
         else:
             raise KeyError(f"Object of type {self.item.__class__.__name__} does " +
-                           "not contain a field with name {field_name}")
+                           f"not contain a field with name {field_name}")
 
     def __iter__(self) -> Iterator:
         fields = [attr for attr in self._fields_dict if hasattr(self.item, attr)]

--- a/autoextract_poet/adapters.py
+++ b/autoextract_poet/adapters.py
@@ -1,0 +1,64 @@
+from types import MappingProxyType
+from typing import Any, KeysView, Iterator
+
+from itemadapter.adapter import AttrsAdapter
+
+from autoextract_poet.items import Item
+
+
+class AutoExtractAdapter(AttrsAdapter):
+    """
+    ``ItemAdapter`` for AutoExtract poet items. The advantage of
+    this adapter over the default one is that any new attributes
+    no present in the item definition are also preserved and serialized.
+    This ensures compatibility with the addition of new attributes
+    in the AutoExtract API.
+
+    Remember that this adapter should be enabled by invoking::
+
+        ItemAdapter.ADAPTER_CLASSES.appendleft(AutoExtractAdapter)
+    """
+    def __init__(self, item: Any) -> None:
+        super().__init__(item)
+
+    @classmethod
+    def is_item(cls, item: Any) -> bool:
+        return isinstance(item, Item)
+
+    def get_field_meta(self, field_name: str) -> MappingProxyType:
+        if field_name in self._fields_dict:
+            return self._fields_dict[field_name].metadata  # type: ignore
+        else:
+            return MappingProxyType({})
+
+    def field_names(self) -> KeysView:
+        return KeysView({**self._fields_dict, **self.item._additional_attrs})
+
+    def __getitem__(self, field_name: str) -> Any:
+        if field_name in self._fields_dict:
+            return getattr(self.item, field_name)
+        elif field_name in self.item._additional_attrs:
+            return self.item._additional_attrs[field_name]
+        raise KeyError(field_name)
+
+    def __setitem__(self, field_name: str, value: Any) -> None:
+        if field_name in self._fields_dict:
+            setattr(self.item, field_name, value)
+        else:
+            self.item._additional_attrs[field_name] = value
+
+    def __delitem__(self, field_name: str) -> None:
+        if field_name in self._fields_dict:
+            try:
+                delattr(self.item, field_name)
+            except AttributeError:
+                raise KeyError(field_name)
+        elif field_name in self.item._additional_attrs:
+            del self.item._additional_attrs[field_name]
+        else:
+            raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
+
+    def __iter__(self) -> Iterator:
+        fields = [attr for attr in self._fields_dict if hasattr(self.item, attr)]
+        fields.extend(attr for attr in self.item._additional_attrs if attr not in fields)
+        return iter(fields)

--- a/autoextract_poet/adapters.py
+++ b/autoextract_poet/adapters.py
@@ -56,7 +56,8 @@ class AutoExtractAdapter(AttrsAdapter):
         elif field_name in self.item._additional_attrs:
             del self.item._additional_attrs[field_name]
         else:
-            raise KeyError(f"{self.item.__class__.__name__} does not support field: {field_name}")
+            raise KeyError(f"Object of type {self.item.__class__.__name__} does " +
+                           "not contain a field with name {field_name}")
 
     def __iter__(self) -> Iterator:
         fields = [attr for attr in self._fields_dict if hasattr(self.item, attr)]

--- a/autoextract_poet/adapters.py
+++ b/autoextract_poet/adapters.py
@@ -8,11 +8,18 @@ from autoextract_poet.items import Item
 
 class AutoExtractAdapter(AttrsAdapter):
     """
-    ``ItemAdapter`` for AutoExtract poet items. The advantage of
-    this adapter over the default one is that any new attributes
-    no present in the item definition are also preserved and serialized.
-    This ensures compatibility with the addition of new attributes
-    in the AutoExtract API.
+    ``ItemAdapter`` for AutoExtract poet items that deals transparently with
+    both the ``attr.s`` defined fields and the rest of unknown
+    fields received at item initialization.
+
+    The utility is twofold. Firstly, it serves to ensure the
+    pass-through of new fields from the API even if ``autoextract-poet``
+    item definitions have not been yet updated. In other words,
+    it can be used to create spiders that preserve all the data coming
+    from the API even if they don't have updated item definitions.
+
+    Secondly, it offers a common interface to access and modify both kind of
+    fields (known and unknown).
 
     Remember that this adapter should be enabled by invoking::
 

--- a/autoextract_poet/items.py
+++ b/autoextract_poet/items.py
@@ -6,32 +6,32 @@ from .util import split_in_unknown_and_known_fields
 
 
 class _ItemBase:
-    # Reserving an slot for _additional_attrs.
+    # Reserving an slot for _unknown_fields_dict.
     # This is done in a base class because otherwise attr.s won't pick it up
-    __slots__ = ("_additional_attrs", )
+    __slots__ = ("_unknown_fields_dict", )
 
 
 @attr.s(auto_attribs=True, slots=True)
 class Item(_ItemBase):
 
     def __attrs_post_init__(self):
-        self._additional_attrs = {}
+        self._unknown_fields_dict = {}
 
     @classmethod
     def from_dict(cls, item: Optional[Dict]):
         """
         Read an item from a dictionary.
 
-        Unknown attributes are kept in the dict ``_additional_attrs``
-        so that they can be serialized also by the ``AutoExtractAdapter``.
-        This ensures supporting new AutoExtract attributes even if the
+        Unknown attributes are kept in the dict ``_unknown_fields_dict``
+        so that ``AutoExtractAdapter`` can include them in the resultant item.
+        This ensures supporting new AutoExtract fields even if the
         item library is not in sync.
         """
         if not item:
             return None
-        unknown_attrs, known_attrs = split_in_unknown_and_known_fields(item, cls)
-        obj = cls(**known_attrs)  # type: ignore
-        obj._additional_attrs = unknown_attrs
+        unknown_fields, known_fields = split_in_unknown_and_known_fields(item, cls)
+        obj = cls(**known_fields)  # type: ignore
+        obj._unknown_fields_dict = unknown_fields
         return obj
 
     @classmethod

--- a/autoextract_poet/items.py
+++ b/autoextract_poet/items.py
@@ -37,8 +37,7 @@ class Item(_ItemBase):
     @classmethod
     def from_list(cls, items: Optional[List[Dict]]) -> List:
         """
-        Read items from a list, ignoring unknown attributes for
-        backwards compatibility
+        Read items from a list, invoking ``from_dict`` for each item in the list
         """
         return [cls.from_dict(item) for item in items or []]
 

--- a/autoextract_poet/util.py
+++ b/autoextract_poet/util.py
@@ -1,4 +1,4 @@
-from typing import Type, Optional
+from typing import Type, Optional, Tuple, Dict, Callable, Any
 from weakref import WeakKeyDictionary
 
 import attr
@@ -8,15 +8,35 @@ import attr
 CLASS_ATTRS: WeakKeyDictionary = WeakKeyDictionary()
 
 
-def remove_unknown_fields(data: Optional[dict], item_cls: Type) -> dict:
-    """Return a dict where those elements not belonging to the
-    attr class ``item_cls`` definition are removed. This dict is then safe to
-    be used to create items for the given class. Can be used to ensure
-    that new attributes returned from the API does not break the library"""
+def split_in_unknown_and_known_fields(data: Optional[dict], item_cls: Type) -> Tuple[Dict, Dict]:
+    """
+    Return a pair of dicts. The first one contains those elements not belonging to the
+    attr class ``item_cls``. The second one contains the rest. That is, those
+    attributes not belonging to ``item_cls`` class
+    """
     data = data or {}
     if not attr.has(item_cls):
         raise ValueError(f"The cls {item_cls} is not attr.s class")
-
     if not item_cls in CLASS_ATTRS:
         CLASS_ATTRS[item_cls] = {field.name for field in attr.fields(item_cls)}
-    return {k: v for k, v in data.items() if k in CLASS_ATTRS[item_cls]}
+    unknown, known = split_dict(data, lambda k: k in CLASS_ATTRS[item_cls])
+    return unknown, known
+
+
+def split_dict(dict: Dict, key_pred: Callable[[Any], Any]) -> Tuple[Dict, Dict]:
+    """
+    Splits the dictionary in two. The first dict contains the records
+    for which the key predicate is False and the second dict contains the rest
+
+    >>> split_dict({}, lambda k: False)
+    ({}, {})
+    >>> split_dict(dict(a=1, b=2, c=3), lambda k: k != 'a')
+    ({'a': 1}, {'b': 2, 'c': 3})
+    """
+    yes, no = {}, {}
+    for k, v in dict.items():
+        if key_pred(k):
+            yes[k] = v
+        else:
+            no[k] = v
+    return (no, yes)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     packages=find_packages(exclude=['tests',]),
     install_requires=[
         'attrs',
+        'itemadapter',
         'web-poet',
     ],
     classifiers=[

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -1,0 +1,134 @@
+from typing import Optional
+
+import attr
+import pytest
+from itemadapter import ItemAdapter
+
+from autoextract_poet.adapters import AutoExtractAdapter
+from autoextract_poet.items import Item
+
+
+@attr.s(auto_attribs=True, slots=True)
+class ItemTest(Item):
+    attr1: Optional[int] = attr.ib(default=None, metadata={"meta": "example"})
+    attr2: Optional[str] = None
+
+
+@attr.s(auto_attribs=True, slots=True)
+class NonItem:
+    attr1: str = "Not extending Item"
+
+
+@pytest.fixture
+def item_adapter():
+    ItemAdapter.ADAPTER_CLASSES.appendleft(AutoExtractAdapter)
+    yield ItemAdapter
+    ItemAdapter.ADAPTER_CLASSES.popleft()
+
+
+@pytest.fixture
+def item() -> AutoExtractAdapter:
+    return ItemTest.from_dict(dict(attr1=1,
+                                   attr2="regular",
+                                   attr3="additional1",
+                                   attr4="additional2"))
+
+
+
+@pytest.fixture
+def adapted_item(item) -> AutoExtractAdapter:
+    return AutoExtractAdapter(item)
+
+
+@pytest.fixture
+def empty_item() -> AutoExtractAdapter:
+    return AutoExtractAdapter(Item())
+
+
+def test_is_item():
+    assert AutoExtractAdapter.is_item(ItemTest()) is True
+    assert AutoExtractAdapter.is_item("Not an item") is False
+    assert AutoExtractAdapter.is_item(NonItem()) is False
+
+
+def test_get_field_meta(adapted_item):
+    assert adapted_item.get_field_meta("attr1") == {"meta": "example"}
+    assert adapted_item.get_field_meta("attr2") == {}
+    assert adapted_item.get_field_meta("attr3") == {}
+    assert adapted_item.get_field_meta("anything_else") == {}
+
+
+def test_field_names(adapted_item):
+    expected = ["attr1", "attr2", "attr3", "attr4"]
+    assert list(adapted_item.field_names()) == expected
+    adapted_item.item._additional_attrs['attr1'] = "duplicated"
+    assert list(adapted_item.field_names()) == expected
+
+
+def test_field_names_on_empty(empty_item):
+    assert not empty_item.field_names()
+    empty_item.item._additional_attrs['attr'] = "additional"
+    assert list(empty_item.field_names()) == ['attr']
+
+
+def test_getitem_setitem(adapted_item, empty_item):
+    assert adapted_item["attr1"] == 1
+    assert adapted_item["attr2"] == "regular"
+    assert adapted_item["attr3"] == "additional1"
+    assert adapted_item["attr4"] == "additional2"
+
+    # Checking that we can set and then get any value. This covers the three
+    # cases: attrs attribs, additional attribs and new additional attribs
+    for item in [adapted_item, empty_item]:
+        for idx in range(1, 6):
+            item[f"attr{idx}"] = f"new_{idx}"
+        for idx in range(1, 6):
+            assert item[f"attr{idx}"] == f"new_{idx}"
+
+
+def test_delitem(adapted_item):
+    del adapted_item["attr1"]
+    assert len(adapted_item) == 3
+    del adapted_item["attr2"]
+    assert len(adapted_item) == 2
+    del adapted_item["attr3"]
+    assert len(adapted_item) == 1
+    del adapted_item["attr4"]
+    assert len(adapted_item) == 0
+
+    with pytest.raises(KeyError):
+        del adapted_item["attr5"]
+
+    with pytest.raises(KeyError):
+        del adapted_item["attr1"]
+
+
+@pytest.mark.xfail(reason="deleting an attrs makes the object unserialiable with attr")
+def test_serialization_after_deletion(adapted_item):
+    del adapted_item["attr1"]
+    assert len(attr.asdict(adapted_item.item)) == 3
+
+
+def test_iter(adapted_item, empty_item):
+    assert list(empty_item) == []
+    assert list(adapted_item) == [f"attr{idx}" for idx in range(1, 5)]
+    del adapted_item["attr1"]
+    assert list(adapted_item) == [f"attr{idx}" for idx in range(2, 5)]
+    del adapted_item["attr4"]
+    assert list(adapted_item) == [f"attr{idx}" for idx in range(2, 4)]
+
+
+def test_asdict(item_adapter, item):
+    # Order is important
+    expected = list(dict(attr1=1,
+                    attr2="regular",
+                    attr3="additional1",
+                    attr4="additional2").items())
+    adapted_item = item_adapter(item)
+    assert list(adapted_item.asdict().items()) == expected
+
+    # Items should be serializable after attr.s attributes removal
+    del adapted_item["attr1"]
+    assert list(adapted_item.asdict().items()) == [("attr2", "regular"),
+                                                   ("attr3", "additional1"),
+                                                   ("attr4", "additional2")]

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -61,13 +61,13 @@ def test_get_field_meta(adapted_item):
 def test_field_names(adapted_item):
     expected = ["attr1", "attr2", "attr3", "attr4"]
     assert list(adapted_item.field_names()) == expected
-    adapted_item.item._additional_attrs['attr1'] = "duplicated"
+    adapted_item.item._unknown_fields_dict['attr1'] = "duplicated"
     assert list(adapted_item.field_names()) == expected
 
 
 def test_field_names_on_empty(empty_item):
     assert not empty_item.field_names()
-    empty_item.item._additional_attrs['attr'] = "additional"
+    empty_item.item._unknown_fields_dict['attr'] = "additional"
     assert list(empty_item.field_names()) == ['attr']
 
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,5 +1,3 @@
-from pprint import pprint
-
 import attr
 import pytest
 

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -37,7 +37,7 @@ example_product_list_result = load_fixture("sample_product_list.json")[0]
 def test_item(cls, data, unexpected_attrs):
     item = cls.from_dict({**data, **unexpected_attrs})
     assert attr.asdict(item) == data
-    assert item._additional_attrs == unexpected_attrs
+    assert item._unknown_fields_dict == unexpected_attrs
 
     with temp_seed(7):
         for _ in range(10):

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,3 +1,5 @@
+from pprint import pprint
+
 import attr
 import pytest
 
@@ -30,9 +32,14 @@ example_product_list_result = load_fixture("sample_product_list.json")[0]
     [(PaginationLink, example_product_list_result["productList"]["paginationNext"])] +  # type: ignore
     [(ProductList, example_product_list_result["productList"])]  # type: ignore
 )  # type: ignore
-def test_item(cls, data):
-    item = cls.from_dict({**data, "unexpected_attribute": "Should not fail"})
+@pytest.mark.parametrize(
+    "unexpected_attrs",
+    [{}, {"unexpected_attribute": "Should not fail"}]
+)  # type: ignore
+def test_item(cls, data, unexpected_attrs):
+    item = cls.from_dict({**data, **unexpected_attrs})
     assert attr.asdict(item) == data
+    assert item._additional_attrs == unexpected_attrs
 
     with temp_seed(7):
         for _ in range(10):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,22 +1,27 @@
 import attr
 import pytest
 
-from autoextract_poet.util import remove_unknown_fields
+from autoextract_poet.util import split_in_unknown_and_known_fields
 
 
-@attr.s(auto_attribs=True)
+@attr.s(auto_attribs=True, slots=True)
 class _TestItem:
     k1: int
     k2: int
 
 
-def test_remove_unknown_fields():
-    expected = dict(k1=1, k2=2)
-    prep1 = remove_unknown_fields(dict(k1=1, k2=2, extra=3), _TestItem)
-    prep2 = remove_unknown_fields(dict(k1=1, k2=2, extra=3), _TestItem)
-    assert prep1 == prep2
-    assert prep2 == expected
-    assert attr.asdict(_TestItem(**prep2)) == expected
+def test_split_in_unknown_and_known_fields():
+    input = dict(k1=1, k2=2, extra=3)
+    unknown, known = split_in_unknown_and_known_fields(input, _TestItem)
+    assert attr.asdict(_TestItem(**known)) == dict(k1=1, k2=2)
+    assert unknown == dict(extra=3)
+
+    unknown, known = split_in_unknown_and_known_fields(known, _TestItem)
+    assert unknown == {}
+
+    for empty_input in ({}, None):
+        ret = split_in_unknown_and_known_fields(empty_input, _TestItem)
+        assert ret == ({}, {})
 
     with pytest.raises(ValueError):
-        remove_unknown_fields(expected, str)
+        split_in_unknown_and_known_fields(input, str)


### PR DESCRIPTION
Unknown attributes are now preserved in the items internal property `_additional_attrs` and the new `AutoExtractAdapter` is able to include them when exported as `dict`. 

The advantage is that users using an old version of the client library will be able to support any newly added attributes in AutoExtract API without intervention.