### PR TITLE
allow to get item class for a page input without creating an object

### DIFF
--- a/autoextract_poet/page_inputs.py
+++ b/autoextract_poet/page_inputs.py
@@ -46,10 +46,23 @@ class AutoExtractData(Generic[T]):
 
     @property
     def item_class(self):
-        return self.__orig_bases__[0].__args__[0]
+        return get_item_class(self)
 
     def to_item(self) -> Optional[T]:
         return self.item_class.from_dict(self.data[self.page_type])
+
+
+def get_item_class(page_input_cls):
+    """ Return item class for the page input class.
+
+    >>> get_item_class(AutoExtractArticleData) is Article
+    True
+    >>> get_item_class(AutoExtractProductData) is Product
+    True
+    >>> get_item_class(AutoExtractData) is T
+    True
+    """
+    return page_input_cls.__orig_bases__[0].__args__[0]
 
 
 @export

--- a/autoextract_poet/page_inputs.py
+++ b/autoextract_poet/page_inputs.py
@@ -1,4 +1,4 @@
-from typing import ClassVar, Generic, Optional, TypeVar
+from typing import ClassVar, Generic, Optional, TypeVar, Type
 
 import attr
 
@@ -52,7 +52,7 @@ class AutoExtractData(Generic[T]):
         return self.item_class.from_dict(self.data[self.page_type])
 
 
-def get_item_class(page_input_cls):
+def get_item_class(page_input_cls: Type[AutoExtractData]) -> Type[Item]:
     """ Return item class for the page input class.
 
     >>> get_item_class(AutoExtractArticleData) is Article
@@ -62,7 +62,7 @@ def get_item_class(page_input_cls):
     >>> get_item_class(AutoExtractData) is T
     True
     """
-    return page_input_cls.__orig_bases__[0].__args__[0]
+    return page_input_cls.__orig_bases__[0].__args__[0]  # type: ignore[attr-defined]
 
 
 @export


### PR DESCRIPTION
Ideally, we should convert AutoExtractData.item_class to a "class property", as it doesn't actually need an instance, just the class. But there is no built-in classproperty in Python, and doing it with metaclasses or descriptors is a bit cumbersome; it would complicate the code. 

So I added a helper function instead. 

Initially it was added as a classmethod, but I changed it to a function; classmethod looked a bit weird - why have item_class property which works only on instance, and get_item_class() method, which works everywhere? By having a separate function I'm trying to hide this issue :) No strong opinion on that.

